### PR TITLE
changed the dromedary to a bactrian

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -74,7 +74,7 @@ let init level =
       level;
     }
 
-let camel_string = "🐪"
+let camel_string = "🐫"
 let cactus_string = "🌵"
 let invisible_string = "\u{200E}"
 


### PR DESCRIPTION
Regarding recent events [on X](https://x.com/edwinansari/status/1887517387324309946), it seemed good to add a slight correction to the incomparable Mine Sweeper clone, Camel Finder.

As we know, there are two well known programming languages which are associated with camels.

Perl was first associated with the camel with O'Reilly Media's 1991 publication of _Programming Perl_. O'Reilly historically has decorated their books with pictures of animals.

![image](https://github.com/user-attachments/assets/742cec3b-1898-43dd-9760-e3ff58736138)

O'Reilly also licenses a "republic-of-perl" logo for use with non-commercial Perl projects.

![image](https://github.com/user-attachments/assets/4f99c771-4471-487d-9c50-f630206f590a)

Perhaps somewhat ironically, the official logo of the Perl foundation is a pearl onion. Nonetheless, the camel remains closely associated with Perl in the popular consciousness of programmers.

Around the same time Perl appeared, a much less popular, much more correct albeit less practical dialect of ML appeared in France called Caml, and I suppose it is obvious why this language might also be associated with the camel. while I don't know when the Caml logo first appeared, it also features a camel.

![image](https://github.com/user-attachments/assets/1a489041-98bd-4234-9a13-653c662dcad8)

While there have been several implementations of Caml, the most well known and certainly the most practical (perhaps even as practical as Perl) is OCaml, first appearing in 1996 with name Objective Caml, which was officially changed to OCaml in 2011. Like Caml before it, OCaml also uses a camel in the logo:

![image](https://github.com/user-attachments/assets/a0025905-48be-4ffd-9311-013bc340c5c4)

In 2014, OCaml got its own O'Reilly book, _Real World OCaml_, which also features a camel on the the cover, albeit a very different camel than the one appearing on the Perl book.

![image](https://github.com/user-attachments/assets/0bae6d30-f4ea-47a3-b402-7b2cece1db11)

-------------------

If you carefully observe all of this iconography, you will notice that Perl is always associated with the single-humped dromedary camel, while Caml and OCaml are always associated with the two-humped bactrian camel

Therefore, I have initiated a pull request to change 🐪 to 🐫, to more accurately reflect the impeccable taste of the author in choosing the OCaml programming language to implement Camel Finder, and to avoid the embarrassment of possibly being associated with Perl in any way.